### PR TITLE
Afoley/as 188 clean cancel ci

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -30,8 +30,8 @@ sites:
   - name: VoxelGPT
     url: $VOXELGPT_CHECK_ENDPOINT
 assignees:
-  - findtopher
   - afoley587
+  - findtopher
 status-website:
   cname: upptime.voxel51.com
   logoUrl: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -25,8 +25,13 @@ sites:
     url: https://voxel51.fiftyone.ai
   - name: www.voxel51.com
     url: http://www.voxel51.com
+  - name: VoxelGPT-Dev
+    url: $VOXELGPT_DEV_CHECK_ENDPOINT
+  - name: VoxelGPT
+    url: $VOXELGPT_CHECK_ENDPOINT
 assignees:
   - findtopher
+  - afoley587
 status-website:
   cname: upptime.voxel51.com
   logoUrl: https://voxel51.com/images/logo/voxel51-logo-horz-color-600dpi.png


### PR DESCRIPTION
I cancelled the GH action mid-run... so that the history/readme/etc. didnt get updated on this branch. Those github actions are what adds all of the history. Here's an example https://github.com/voxel51/upptime/actions/runs/10902750477 . It happened on our last actual PR (https://github.com/voxel51/upptime/pull/1). If we want the voxelgpt things, I can also just merge to `main` directly and bypass the PRs