### PR TITLE
feat(staging): update the staging.fiftyone.ai check to validate staging.rc.fiftyone.ai

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -15,8 +15,8 @@ sites:
       - 401
   - name: pypi.voxel51.com
     url: https://pypi.voxel51.com
-  - name: staging.fiftyone.ai
-    url: https://staging.fiftyone.ai/api/hello
+  - name: staging.rc.fiftyone.ai
+    url: https://staging.rc.fiftyone.ai/api/hello
   - name: try.fiftyone.ai
     url: https://try.fiftyone.ai/api/hello
   - name: voxel51.com


### PR DESCRIPTION
We recently changed staging.fiftyone.ai to staging.rc.fiftyone.ai.  Let's update the upptime check.

<img width="588" alt="Screenshot 2024-11-12 at 2 49 36 PM" src="https://github.com/user-attachments/assets/1ab802da-41e5-4daa-b84e-2d2bf837c070">
